### PR TITLE
Hide unwanted log entry generated by group_exists

### DIFF
--- a/7/rootfs/libos.sh
+++ b/7/rootfs/libos.sh
@@ -25,7 +25,7 @@ user_exists() {
 #########################
 group_exists() {
     local group="${1:?group is missing}"
-    getent group "$group"
+    getent group "$group" >/dev/null 2>&1
 }
 
 ########################
@@ -106,4 +106,27 @@ debug_execute() {
     else
         "$@" >/dev/null 2>&1
     fi
+}
+
+########################
+# Retries a command until timeout
+# Arguments:
+#   $1 - cmd (as a string)
+#   $2 - timeout (in seconds). Default: 60
+#   $3 - step (in seconds). Default: 5
+# Returns:
+#   Boolean
+#########################
+retry_while() {
+    local -r cmd="${1:?cmd is missing}"
+    local -r timeout="${2:-60}"
+    local -r step="${3:-5}"
+    local return_value=1
+
+    read -r -a command <<< "$cmd"
+    for ((i = 0 ; i <= timeout ; i+=step )); do
+        "${command[@]}" && return_value=0 && break
+        sleep "$step"
+    done
+    return $return_value
 }


### PR DESCRIPTION
The `group_exists` function is not hiding the output it generates, and therefore things such as the following happen:

```bash
$ group_exists myuser && echo hello
myuser:x:1000:myuser
hello
```

With this PR, `group_exists` will not throw any output (which is OK, since we're only interested in the exit code).

Related change: https://github.com/bitnami/minideb-extras-base/pull/297